### PR TITLE
Use timer-with-reservoir for the 3-arity deftimer

### DIFF
--- a/metrics-clojure-core/src/metrics/timers.clj
+++ b/metrics-clojure-core/src/metrics/timers.clj
@@ -50,7 +50,7 @@
      `(def ~s (timer ~reg '~title))))
   ([^MetricRegistry reg ^Reservoir reservoir title]
    (let [[s title] (desugared-title title)]
-     `(def ~s (timer ~reg ~reservoir '~title)))))
+     `(def ~s (timer-with-reservoir ~reg ~reservoir '~title)))))
 
 (defn rate-one
   [^Timer m]

--- a/metrics-clojure-core/test/metrics/test/timers_test.clj
+++ b/metrics-clojure-core/test/metrics/test/timers_test.clj
@@ -18,10 +18,14 @@
 
 (let [reg (mc/new-registry)]
   (mt/deftimer reg ["test" "timers" "deftimered"])
+  (mt/deftimer reg (mc/uniform-reservior) deftimered-3-arity)
 
   (deftest test-deftimer
     (is (= (mt/rate-mean deftimered) 0.0))
     (is (= (mt/time! deftimered (sleep-100)) 100))
+    (is (> (mt/rate-mean deftimered) 0.0))
+    (is (= (mt/rate-mean deftimered-3-arity) 0.0))
+    (is (= (mt/time! deftimered-3-arity (sleep-100))))
     (is (> (mt/rate-mean deftimered) 0.0))))
 
 


### PR DESCRIPTION
Previously the 3-arity of deftimer was broken, as it used the `timer` function which only had the 2-arity implementation defined. This will update deftimer to use the already working `timer-with-reservoir` function for this case.