### PR TITLE
Bump upstream influx reporter version to latest release

### DIFF
--- a/metrics-clojure-influxdb/project.clj
+++ b/metrics-clojure-influxdb/project.clj
@@ -4,4 +4,4 @@
   :license {:name "MIT"}
   :profiles {:dev {:global-vars {*warn-on-reflection* true}}}
   :dependencies [[metrics-clojure "3.0.0-SNAPSHOT"]
-                 [com.izettle/dropwizard-metrics-influxdb "1.1.8"]])
+                 [com.izettle/dropwizard-metrics-influxdb "1.2.2"]])


### PR DESCRIPTION
The changes that I can see between 1.1.8 and 1.2.2:

- most significantly (and the reason for minor version bump), adds
  p75, p95, and p999 to default fields pushed for timers. Previously
  it was only pushing p50, p99, and 1-minute rate.
- adds support for Kafka and Log-based senders
- some minor bugfixes with time handling on TCP and UDP protos
- support for optional tags transformer, which supports adding tags
  based on metric name