### PR TITLE
Update Riemann client dependency to 0.4.6

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,10 @@
-## Changes Between 2.10.0 and 2.11.0 (unreleased)
 
-No changes yet.
+## Changes Between 2.10.0 and 3.0.0 (unreleased)
+
+
+### Riemann Client updated
+
+Riemann Client was migrated to io.riemann package from com.aphyr as of version 0.4.3.
 
 
 ## Changes Between 2.9.0 and 2.10.0 (Sep 19th, 2017)

--- a/metrics-clojure-riemann/project.clj
+++ b/metrics-clojure-riemann/project.clj
@@ -4,4 +4,4 @@
   :license {:name "MIT"}
   :profiles {:dev {:global-vars {*warn-on-reflection* true}}}
   :dependencies [[metrics-clojure "3.0.0-SNAPSHOT"]
-                 [com.aphyr/metrics3-riemann-reporter "0.4.1"]])
+                 [io.riemann/metrics3-riemann-reporter "0.4.6"]])

--- a/metrics-clojure-riemann/src/metrics/reporters/riemann.clj
+++ b/metrics-clojure-riemann/src/metrics/reporters/riemann.clj
@@ -2,7 +2,7 @@
   (:require [metrics.core :refer [default-registry]])
   (:import [java.util.concurrent TimeUnit]
            [com.codahale.metrics.riemann Riemann RiemannReporter RiemannReporter$Builder]
-           [com.aphyr.riemann.client IRiemannClient]))
+           [io.riemann.riemann.client IRiemannClient]))
 
 (defn make-riemann
   ([riemann-client]


### PR DESCRIPTION
Incorporates namespace change from com.aphyr to io.riemann