### PR TITLE
bump cheshire version to latest 5.10.0

### DIFF
--- a/metrics-clojure-ring/project.clj
+++ b/metrics-clojure-ring/project.clj
@@ -2,7 +2,7 @@
   :description "Various things gluing together metrics-clojure and ring."
   :url "https://github.com/sjl/metrics-clojure"
   :license {:name "MIT"}
-  :dependencies [[cheshire "5.8.0"]
+  :dependencies [[cheshire "5.10.0"]
                  [metrics-clojure "3.0.0-SNAPSHOT"]]
   :profiles {:dev {:global-vars {*warn-on-reflection* true}
                    :dependencies [[ring "1.4.0"]


### PR DESCRIPTION
This tiny PR only bumps Cheshire version to 5.10.0 - the tests pass with this change in my setup.